### PR TITLE
Improve Standard Linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-eslint": "^4.1.6",
     "babel-preset-es2015-node5": "^1.1.1",
     "babel-preset-stage-0": "^6.3.13",
+    "husky": "^0.10.2",
     "rimraf": "^2.4.5",
     "snazzy": "^2.0.1",
     "standard": "^5.4.1"
@@ -44,6 +45,7 @@
     "url": "git://github.com/carrot/roots-mini.git"
   },
   "scripts": {
+    "precommit": "npm run lint -s",
     "start": "webpack",
     "lint": "standard --verbose | snazzy",
     "pretest": "npm run lint -s",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bugs": {
     "url": "https://github.com/carrot/roots-mini/issues"
   },
+  "standard": {
+    "parser": "babel-eslint"
+  },
   "dependencies": {
     "autoprefixer": "^6.1.2",
     "glob": "^6.0.1",
@@ -21,9 +24,11 @@
   "devDependencies": {
     "ava": "sindresorhus/ava",
     "babel-core": "^6.3.26",
+    "babel-eslint": "^4.1.6",
     "babel-preset-es2015-node5": "^1.1.1",
     "babel-preset-stage-0": "^6.3.13",
     "rimraf": "^2.4.5",
+    "snazzy": "^2.0.1",
     "standard": "^5.4.1"
   },
   "homepage": "https://github.com/carrot/roots-mini",
@@ -39,7 +44,9 @@
     "url": "git://github.com/carrot/roots-mini.git"
   },
   "scripts": {
-    "start": "./node_modules/.bin/webpack",
-    "test": "./node_modules/.bin/standard && ./node_modules/.bin/ava"
+    "start": "webpack",
+    "lint": "standard --verbose | snazzy",
+    "pretest": "npm run lint -s",
+    "test": "ava"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 import 'babel-core/register'
 import path from 'path'
 import fs from 'fs'
-import rimraf from 'rimraf'
+// import rimraf from 'rimraf'
 import test from 'ava'
 import helpers from './_helpers'
 


### PR DESCRIPTION
- [Standard](/feross/standard) is not aware of Babel by default - this PR adds a `standard` property to `package.json` that sets the `eslint` parser to `babel-eslint`. This _should supposedly_ obtain the config from `.babelrc`.

- Cleaned up the `npm scripts` somewhat - there is no need to use `node_modules/.bin/package` as `package` inside an `npm script` will automatically resolve to the binary. 

- Extracted the `lint` logic out to it's own script so tests need not be run if all you want is just to lint the files. 

- Added `pre-commit` linting to prevent invalid code from entering the remote repo - thanks to [Husky](/typicode/husky). Bypass this by passing `--no-verify` along with your `git` commands

Unfortunately, `standard` throws a non-zero exit which clutters the lint output with unnecessary error messages asking the developer to file an issue with the author of `roots-mini` (a bit over the top for lint errors, eh?) - I've managed to suppress these when running `npm test` by passing in `-s` (aka `--silent`) to `npm run`, but this can't be used everywhere (like in `pre-commit`, or in another `npm script` definition for instance). But for the most part, it makes failing tests a little easier to grep. 

Finally, I've improved the output a little thanks to the help of [Snazzy](/feross/snazzy). Here's a before and after of the `npm test` output when there is a linting error:

**Before:**
![before](https://infinit.io/_/XT4tVsZ.png)

**After:**
![after](https://infinit.io/_/TzA3krZ.png)