### PR TITLE
require node 5 and npm 3 engines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.11"
-  - "0.10"
-  - "iojs"
+  - "5"
 sudo: false

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
     "snazzy": "^2.0.1",
     "standard": "^5.4.1"
   },
+  "engines": {
+    "node": ">=5.0.0",
+    "npm": ">=3.0.0"
+  },
   "homepage": "https://github.com/carrot/roots-mini",
   "keywords": [
     "roots",


### PR DESCRIPTION
This is a separate PR from `async-tests` (to be merged into `async-tests`) in case we decide this isn't the best way forward and want to support older engines

I just discovered that we use `babel-preset-es2015-node-5` rather than `babel-preset-es2015`. The former only transpiles ES2015 features that Node v5 does not already support, whereas the latter transpiles everything. Therefore, it doesn't make sense to test Node `0.10`-`0.12` or `iojs` on Travis - since `roots-mini` doesn't support those engines. I've also added an `engines` field to `package.json` which should warn about this when `roots-mini` is installed.