### PR TITLE
CLI & Better Error Handling

### DIFF
--- a/bin/roots
+++ b/bin/roots
@@ -6,7 +6,8 @@ require('babel-core/register')
 var CLI = require('../lib/cli').default
 var cli = new CLI()
 
-cli.run(process.argv.slice(2))
+cli.on('error', function (err) { console.error(err.stack) })
+cli.on('warning', function (warn) { console.warn(warn.stack) })
+cli.on('compile', console.log)
 
-cli.on('data', console.log)
-cli.on('error', console.error)
+cli.run(process.argv.slice(2))

--- a/bin/roots
+++ b/bin/roots
@@ -3,11 +3,23 @@
 // TODO: remove this before shipping
 require('babel-core/register')
 
+var chalk = require('chalk')
 var CLI = require('../lib/cli').default
 var cli = new CLI()
 
-cli.on('error', function (err) { console.error(err.stack) })
-cli.on('warning', function (warn) { console.warn(warn.stack) })
-cli.on('compile', console.log)
+cli.on('error', function (err) {
+  console.error(chalk.red('ERROR'))
+  console.error(err.stack)
+})
+
+cli.on('warning', function (warn) {
+  console.warn(chalk.yellow('WARNING'))
+  console.warn(warn.stack)
+})
+
+cli.on('compile', function (res) {
+  console.log(chalk.green('compiled!'))
+  console.log(res)
+})
 
 cli.run(process.argv.slice(2))

--- a/bin/roots
+++ b/bin/roots
@@ -18,8 +18,8 @@ cli.on('warning', function (warn) {
 })
 
 cli.on('compile', function (res) {
-  console.log(chalk.green('compiled!'))
-  console.log(res)
+  var compileTime = (res.stats.endTime - res.stats.startTime) / 1000
+  console.log(chalk.green('compiled') + ' ' + chalk.gray('(' + compileTime + 's)'))
 })
 
 cli.run(process.argv.slice(2))

--- a/lib/cli/compile.js
+++ b/lib/cli/compile.js
@@ -1,6 +1,4 @@
-import Roots from '../'
-
-export default function (context, args) {
-  let project = new Roots({ root: args.path })
-  return project.compile()
+export default function (project) {
+  project.compile()
+  return project
 }

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1,5 +1,6 @@
 import {EventEmitter} from 'events'
 import {ArgumentParser} from 'argparse'
+import Roots from '../'
 import pkg from '../../package.json'
 
 export default class CLI extends EventEmitter {
@@ -27,14 +28,16 @@ export default class CLI extends EventEmitter {
     let project
 
     try {
-      project = fn(this, args)
+      project = new Roots({ root: args.path })
     } catch (err) {
-      this.emit('error', err)
+      return this.emit('error', err)
     }
 
-    project
-      .then((res) => { console.log(res); this.emit('data', res) })
-      .catch((err) => { console.log(err); this.emit('error', err) })
+    project.on('error', this.emit.bind(this, 'error'))
+    project.on('warning', this.emit.bind(this, 'warning'))
+    project.on('compile', this.emit.bind(this, 'compile'))
+
+    fn(project)
 
     return this
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -99,7 +99,7 @@ export default class Config {
     try {
       let contents = transformFileSync(filename, {
         filename: filename,
-        presets: [require('babel-preset-es2015'), require('babel-preset-stage-2')]
+        presets: ['es2015', 'stage-2']
       }).code
       let mod = _eval(contents)
       res = mod.__esModule ? mod.default : mod

--- a/lib/config.js
+++ b/lib/config.js
@@ -38,7 +38,9 @@ export default class Config {
       bundleName: Joi.string().default('bundle.js'),
       dumpDirs: Joi.array().default(['views', 'assets']),
       locals: Joi.object().default({}),
-      ignore: Joi.array().default([])
+      ignore: Joi.array().default([]),
+      entry: Joi.object().default({ main: ['./assets/js/index.js'] }),
+      modulesDirectories: Joi.array().default(['node_modules', 'bower_components'])
     })
 
     let validation = Joi.validate(opts, schema)
@@ -53,13 +55,15 @@ export default class Config {
    * @return {Class} returns self, but with the properties of a webpack config
    */
   transformRootsOptionsToWebpack (opts) {
-    this.entry = { main: ['./app.js'] }
+    this.entry = opts.entry
     this.context = opts.root
 
     this.output = {
       path: path.join(this.context, 'public'),
       filename: opts.bundleName
     }
+
+    this.resolveLoader = { root: path.join(__dirname, '../node_modules') }
 
     this.module = {
       loaders: [
@@ -74,6 +78,8 @@ export default class Config {
       res.push(...opts.postCssPlugins)
       return opts.postCssPlugins
     }
+
+    this.modulesDirectories = opts.modulesDirectories
 
     this.babel = opts.babelConfig
 
@@ -99,7 +105,7 @@ export default class Config {
     try {
       let contents = transformFileSync(filename, {
         filename: filename,
-        presets: ['es2015', 'stage-2']
+        presets: [require('babel-preset-es2015'), require('babel-preset-stage-2')]
       }).code
       let mod = _eval(contents)
       res = mod.__esModule ? mod.default : mod

--- a/lib/config.js
+++ b/lib/config.js
@@ -40,7 +40,8 @@ export default class Config {
       locals: Joi.object().default({}),
       ignore: Joi.array().default([]),
       entry: Joi.object().default({ main: ['./assets/js/index.js'] }),
-      modulesDirectories: Joi.array().default(['node_modules', 'bower_components'])
+      modulesDirectories: Joi.array().default(['node_modules', 'bower_components']),
+      outputDir: Joi.string().default('public')
     })
 
     let validation = Joi.validate(opts, schema)
@@ -59,17 +60,20 @@ export default class Config {
     this.context = opts.root
 
     this.output = {
-      path: path.join(this.context, 'public'),
+      path: path.join(this.context, opts.outputDir),
       filename: opts.bundleName
     }
 
     this.resolveLoader = { root: path.join(__dirname, '../node_modules') }
 
+    // ignore node_modules and output directory automatically
+    opts.ignore.unshift('**/node_modules/**', `${this.output.path}/**`)
+
     this.module = {
       loaders: [
-        { test: mmToRe(opts.matchers.css), exclude: /node_modules/, loader: 'css!postcss' },
-        { test: mmToRe(opts.matchers.js), exclude: /node_modules/, loader: 'babel' },
-        { test: mmToRe(opts.matchers.jade), exclude: /node_modules/, loader: 'jade?pretty=true' }
+        { test: mmToRe(opts.matchers.css), exclude: opts.ignore.map(mmToRe), loader: 'css!postcss' },
+        { test: mmToRe(opts.matchers.js), exclude: opts.ignore.map(mmToRe), loader: 'babel' },
+        { test: mmToRe(opts.matchers.jade), exclude: opts.ignore.map(mmToRe), loader: 'jade?pretty=true' }
       ]
     }
 
@@ -85,7 +89,7 @@ export default class Config {
 
     this.plugins = [
       new JadePlugin({ matcher: opts.matchers.jade, locals: opts.locals, ignore: opts.ignore, dumpDirs: opts.dumpDirs }),
-      new CSSPlugin({ matcher: opts.matchers.css, dumpDirs: opts.dumpDirs })
+      new CSSPlugin({ matcher: opts.matchers.css, ignore: opts.ignore, dumpDirs: opts.dumpDirs })
     ]
 
     this.debug = true

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,9 @@
+export class RootsError extends Error {
+  constructor (args) {
+    super()
+    this.id = args.id
+    this.message = args.message
+  }
+}
+
+export class RootsWarning extends RootsError {}

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,13 @@ export default class Roots {
   compile () {
     return new Promise((resolve, reject) => {
       webpack(this.config, (err, stats) => {
+        // handle all errors
+        // ref: https://webpack.github.io/docs/node.js-api.html#error-handling
         if (err) { return reject(err) }
+        let jsonStats = stats.toJson()
+        if (jsonStats.errors.length > 0) { reject(jsonStats.errors) }
+        if (jsonStats.warnings.length > 0) { reject(jsonStats.warnings) } // we may want to WARN instead of reject
+
         return resolve(stats)
       })
     })

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,23 +1,43 @@
 import webpack from 'webpack'
+import {EventEmitter} from 'events'
 import Config from './config'
+import {RootsError, RootsWarning} from './errors'
 
-export default class Roots {
+export default class Roots extends EventEmitter {
   constructor (opts = {}) {
+    super()
     this.config = new Config(opts)
   }
 
   compile () {
-    return new Promise((resolve, reject) => {
-      webpack(this.config, (err, stats) => {
-        // handle all errors
-        // ref: https://webpack.github.io/docs/node.js-api.html#error-handling
-        if (err) { return reject(err) }
-        let jsonStats = stats.toJson()
-        if (jsonStats.errors.length > 0) { reject(jsonStats.errors) }
-        if (jsonStats.warnings.length > 0) { reject(jsonStats.warnings) } // we may want to WARN instead of reject
+    // Assign this compilation a random id
+    let id = this._id()
 
-        return resolve(stats)
-      })
+    // Compile with webpack
+    webpack(this.config, (err, stats) => {
+      if (err) {
+        return this.emit('error', new RootsError({ id: id, message: err }))
+      }
+
+      // Webpack "soft errors" are classified as warnings in roots. An error is
+      // an error. If it doesn't break the build, it's a warning.
+      let jsonStats = stats.toJson()
+      if (jsonStats.errors.length > 0) {
+        this.emit('warning', new RootsWarning({ id: id, message: jsonStats.errors }))
+      }
+      if (jsonStats.warnings.length > 0) {
+        this.emit('warning', new RootsWarning({ id: id, message: jsonStats.warnings }))
+      }
+
+      this.emit('compile', { id: id, stats: stats })
     })
+
+    // Returns the compilation's ID synchronously, this can be checked against
+    // events emitted from the project instance.
+    return id
+  }
+
+  _id () {
+    return (Math.random().toString(16) + '000000000').substr(2, 8)
   }
 }

--- a/lib/plugins/css_plugin.js
+++ b/lib/plugins/css_plugin.js
@@ -37,12 +37,6 @@ export default class CSSWebpackPlugin {
 
         if (!dep) { throw new Error(`Webpack failed to add entry for ${f}`) }
 
-        if (dep.error) {
-          // TODO: remove when async/await tests are gone
-          console.error(`${dep.error.name}: ${dep.error.message}`)
-          throw new Error(`${dep.error.name}: ${dep.error.message}`)
-        }
-
         let srcFn = dep._source._value
         let src = _eval(srcFn, f) // eslint-disable-line
         src = src[0][1] // this part is questionable, but it is what it is

--- a/lib/plugins/jade_plugin.js
+++ b/lib/plugins/jade_plugin.js
@@ -36,12 +36,6 @@ export default class JadeWebpackPlugin {
 
         if (!dep) { throw new Error(`Webpack failed to add entry for ${f}`) }
 
-        if (dep.error) {
-          // TODO: remove when async/await tests are gone
-          console.error(`${dep.error.name}: ${dep.error.message}`)
-          throw new Error(`${dep.error.name}: ${dep.error.message}`)
-        }
-
         let srcFn = dep._source._value
         let locals = this.opts.locals || {}
         let src = eval(srcFn)(locals) // eslint-disable-line

--- a/lib/plugins/plugin_utils.js
+++ b/lib/plugins/plugin_utils.js
@@ -5,7 +5,7 @@ import SingleEntryDependency from 'webpack/lib/dependencies/SingleEntryDependenc
 export default {
   getFilesFromGlob (compiler, opts) {
     let matcher = path.join(compiler.options.context, opts.matcher)
-    let files = glob.sync(matcher).filter(removeIgnores.bind(null, opts.ignore))
+    let files = glob.sync(matcher, { ignore: opts.ignore })
     return files
   },
   addFilesAsWebpackEntries (files, opts, compiler, compilation) {
@@ -35,13 +35,4 @@ export default {
 
     return rel.substring(1)
   }
-}
-
-// utils
-
-function removeIgnores (ignores, f) {
-  for (let ignore of ignores) {
-    if (f.match(ignore)) { return false }
-  }
-  return true
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-loader": "^6.2.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-2": "^6.3.13",
+    "chalk": "^1.1.1",
     "css-loader": "^0.23.1",
     "glob": "^6.0.1",
     "jade": "^1.11.0",

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,10 @@ The above shows a minimal instantiation, but the constructor accepts a wide vari
 - **bundleName**: The name of your resulting js bundle from webpack. Defaults to `bundle.js`.
 - **dumpDirs**: An array of directories which, if direct children of the project root, will dump their contents to the root on compile. Defaults to `['views', 'assets']`.
 - **locals**: An object containing locals to be passed to jade views. This can be used for values, functions, any sort of view helper you need.
-- **ignore**: An array of regexes, each one defining a file pattern to be ignored from compilation.
+- **ignore**: An array of [micromatch](https://github.com/jonschlinkert/micromatch) strings, each one defining a file pattern to be ignored from compilation.
+- **outputDir**: The name or path of the folder your project will be compiled into, on top of the project's root. Defaults to `'public'`.
+
+> **Note:** Not familiar with minimatch or micromatch? Check out the [minimatch cheat sheet](https://github.com/motemen/minimatch-cheat-sheet) and test your patterns with [globtester](http://www.globtester.com). Trust us, it's a much cleaner and easier way to write regexes for the file system : )
 
 Roots exposes a simpler and more straightforward configuration interface than if you were to set up the webpack configuration yourself. However, if you'd like to directly edit the webpack config, you can still do this after the project has been instantiated through the `config` property on each instance.
 

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -23,5 +23,10 @@ export function compileFixture (t, name, options = {}) {
   let project = new Roots(Object.assign(options, { root: testPath }))
   let publicPath = path.join(testPath, 'public')
 
-  return When(project.compile()).then((res) => { return {res, publicPath} })
+  return When.promise(function (resolve, reject) {
+    project.on('error', reject)
+    project.on('compile', function (res) { resolve({res, publicPath}) })
+
+    project.compile()
+  })
 }

--- a/test/ignores.js
+++ b/test/ignores.js
@@ -6,7 +6,7 @@ import {
 } from './_helpers'
 
 test('does not compile ignored files', (t) => {
-  return compileFixture(t, 'ignores', { ignore: [/layout\.jade/] }).tap(({publicPath}) => {
+  return compileFixture(t, 'ignores', { ignore: ['**/layout.jade'] }).tap(({publicPath}) => {
     return fs.access(path.join(publicPath, 'index.html'))
   }).tap(({publicPath}) => {
     return fs.access(path.join(publicPath, 'about.html'))


### PR DESCRIPTION
ref: https://webpack.github.io/docs/node.js-api.html#error-handling

the tests will fail because it unearths some additional webpack errors that weren't coming back in the `err` param
```js
webpack(this.config, (err, stats) => { //...
```
---

in our configuration, we define the webpack config's `entry` as: 
```js
this.entry = { main: ['./app.js'] }
```
and it looks like webpack needs that file to actually exist because it throws:
```sh
Error: Cannot resolve 'file' or 'directory' ./app.js in /Users/kylemac/Sites/carrot/roots-mini/test/fixtures/dump_dirs
```
fwiw, we're catching the lack of an `app.js` file already here: https://github.com/carrot/roots-mini/blob/cli/lib/config.js#L106-L108 