### PR TITLE
don't set port by default on cli

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -29,7 +29,12 @@ export default class CLI extends EventEmitter {
     let project
 
     try {
-      project = new Roots({ root: args.path, server: { port: args.port } })
+      // pass with server obj if port is defined, otherwise omit server obj
+      if (args.port) {
+        project = new Roots({ root: args.path, server: { port: args.port } })
+      } else {
+        project = new Roots({ root: args.path })
+      }
     } catch (err) {
       return this.emit('error', err)
     }
@@ -66,7 +71,6 @@ export default class CLI extends EventEmitter {
 
     s.addArgument(['--port', '-p'], {
       type: Number,
-      defaultValue: 1111,
       help: 'Port you want to run the local server on (default 1111)'
     })
 


### PR DESCRIPTION
passing `server`, even when port was null was disrupting the logic that used `Object.assign()` to establish default hierarchy. i chose to add a conditional in the CLI logic, as opposed to convoluting the config logic. i'm open for better ideas though...