### PR TITLE
ensure ./node_modules and outputDir aren't watched

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -3,6 +3,7 @@ import Joi from 'joi'
 import JadePlugin from './plugins/jade_plugin'
 import CSSPlugin from './plugins/css_plugin'
 import micromatch from 'micromatch'
+import union from 'lodash.union'
 import _eval from 'require-from-string'
 import {transformFileSync} from 'babel-core'
 import postcssImport from 'postcss-import'
@@ -48,7 +49,9 @@ export default class Config {
         baseDir: Joi.string(),
         ui: [Joi.bool(), Joi.object()],
         files: [Joi.string(), Joi.array()],
-        watchOptions: Joi.object(),
+        watchOptions: Joi.object().default().keys({
+          ignored: Joi.array().default('node_modules')
+        }),
         server: Joi.object().default({}),
         proxy: [Joi.string(), Joi.object(), Joi.bool()],
         middleware: [Joi.func(), Joi.array()],
@@ -94,6 +97,11 @@ export default class Config {
 
     // Joi can't handle defaulting this, so we do it manually
     res.server.server.baseDir = res.outputDir.replace(res.root, '')
+
+    // ensure server.watchOptions.ignored is an array (browsersync accepts string or array)
+    // then push ['node_modules', outputDir] to make sure they're not watched
+    res.server.watchOptions.ignored = Array.prototype.concat(res.server.watchOptions.ignored)
+    res.server.watchOptions.ignored = union(res.server.watchOptions.ignored, ['node_modules', res.outputDir])
 
     return res
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "jade": "^1.11.0",
     "jade-loader": "^0.8.0",
     "joi": "^8.0.1",
+    "lodash.union": "^4.2.0",
     "micromatch": "^2.3.7",
     "postcss": "^5.0.12",
     "postcss-import": "^8.0.2",


### PR DESCRIPTION
fixes #51 

I had to push the outputDir to the end of the array, as I couldn't find a Joi'ish way to go up the chain and get the value of `outputDir` 