### PR TITLE
walk HTML for dependencies and inject into webpack

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -11,6 +11,7 @@ import postcssImport from 'postcss-import'
 import BrowserSyncPlugin from 'browser-sync-webpack-plugin'
 import binaryExtensions from 'binary-extensions'
 import imageExtensions from 'image-extensions'
+import glob from 'glob'
 
 export default class Config {
   constructor (opts) {
@@ -107,6 +108,9 @@ export default class Config {
     res.server.watchOptions.ignored = Array.prototype.concat(res.server.watchOptions.ignored)
     res.server.watchOptions.ignored = union(res.server.watchOptions.ignored, ['node_modules', res.outputDir])
 
+    // log the files within your dumpDirs for intelligent dependency rewrites
+    res.dumpPaths = glob.sync(`*(${res.dumpDirs.join('|')})/**`)
+
     return res
   }
 
@@ -156,7 +160,8 @@ export default class Config {
         locals: opts.locals,
         ignore: opts.ignore,
         dumpDirs: opts.dumpDirs,
-        jadeTemplates: opts.jadeTemplates
+        jadeTemplates: opts.jadeTemplates,
+        dumpPaths: opts.dumpPaths
       }), new CSSPlugin({
         matcher: opts.matchers.css,
         ignore: opts.ignore,

--- a/lib/plugins/jade_plugin.js
+++ b/lib/plugins/jade_plugin.js
@@ -1,4 +1,5 @@
 import util from './plugin_utils'
+import cheerio from 'cheerio'
 
 export default class JadeWebpackPlugin {
 
@@ -34,6 +35,28 @@ export default class JadeWebpackPlugin {
         if (dep.error) { return done(dep.error) }
 
         let src = JSON.parse(dep._source._value)
+
+        // find all HTML asset references
+        // Matching for:
+        // - all nodes with an `src` attribute
+        // - all <link> nodes with an `href` attribute
+        const $ = cheerio.load(src)
+        const srcs = $('[src], link[href]').map(function (i, el) {
+          const attributes = $(this).attr()
+          if ('src' in attributes) {
+            return $(this).attr('src')
+          }
+
+          if ('href' in attributes) {
+            return $(this).attr('href')
+          }
+        }).get()
+
+        // add HTML asset references as dependencies in webpack
+        srcs.forEach((src) => {
+          const p = util.resolveRelativeSourcePath(compiler, src, this.opts)
+          dep.fileDependencies.push(p)
+        })
 
         const outputPath = util.getOutputPath(compiler, f, this.opts)
                              .replace(/\.jade$/, '.html')

--- a/lib/plugins/plugin_utils.js
+++ b/lib/plugins/plugin_utils.js
@@ -43,6 +43,27 @@ export default {
       }
     }
     done()
+  },
+
+  /**
+   * resolveRelativeSourcePath - takes a relative path like `img/foo.png`
+   * and resolves it to an absolute path. Function respects your dumpDirs
+   * and knows how to resolve it's absolute source path
+   *
+   * @param  {obj} compiler the webpack compiler object
+   * @param  {string} file     a relative path
+   * @param  {object} opts     your roots config options
+   * @return {string}          returns an absolute path
+   */
+  resolveRelativeSourcePath (compiler, file, opts) {
+    let rel = file.replace(compiler.options.context)
+
+    // check to see if the file is from a dumpDir path
+    opts.dumpPaths.forEach((d) => {
+      const test = new RegExp(`${rel}`)
+      if (d.match(test)) { rel = d }
+    })
+    return path.join(compiler.options.context, rel)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "browser-sync": "^2.11.1",
     "browser-sync-webpack-plugin": "^1.0.1",
     "chalk": "^1.1.1",
+    "cheerio": "^0.20.0",
     "css-loader": "^0.23.1",
     "file-loader": "carrot/file-loader",
     "glob": "^6.0.1",


### PR DESCRIPTION
- intelligently rewrites deps from a dumpdir
- uses cheerio to traverse HTML

feel like there's optimizations to how we're doing the rewrites for files in dumpdirs. open to suggestions, just wanted to get a proof of concept in place first. 