### PR TITLE
set defaults for babel-core/register

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -187,7 +187,7 @@ export default class Config {
   parseAppJs (root) {
     let res = {}
     const filename = path.join(root, 'app.js')
-    require('babel-core/register')
+    require('babel-core/register')({ presets: ['es2015', 'stage-2'] })
 
     try {
       accessSync(filename)


### PR DESCRIPTION
this was breaking es6 usage when a `.babelrc` wasn't set. 