### PR TITLE
glob the filesystem only once and share w/ plugins

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -156,19 +156,19 @@ export default class Config {
     this.babel = opts.babelConfig
     this.plugins = [
       new JadePlugin({
-        matcher: opts.matchers.jade,
+        matchers: opts.matchers,
         locals: this.locals,
         ignore: opts.ignore,
         dumpDirs: opts.dumpDirs,
         jadeTemplates: opts.jadeTemplates,
         dumpPaths: opts.dumpPaths
       }), new CSSPlugin({
-        matcher: opts.matchers.css,
+        matchers: opts.matchers,
         ignore: opts.ignore,
         dumpDirs: opts.dumpDirs,
         cssTemplates: opts.cssTemplates
       }), new StaticPlugin({
-        matcher: opts.matchers.static,
+        matchers: opts.matchers,
         ignore: opts.ignore,
         dumpDirs: opts.dumpDirs
       }), new BrowserSyncPlugin(opts.server)

--- a/lib/plugins/css_plugin.js
+++ b/lib/plugins/css_plugin.js
@@ -12,19 +12,16 @@ export default class CSSWebpackPlugin {
   }
 
   apply (compiler) {
-    // read file tree and get all css files
-    this.files = util.getFilesFromGlob(compiler, this.opts)
-
     // inject css files into webpack's pipeline
     compiler.plugin('make', (compilation, done) => {
-      util.addFilesAsWebpackEntries(this.files, this.opts, compiler, compilation)
-          .then((res) => done())
+      util.addFilesAsWebpackEntries(compiler.options.files.css, this.opts, compiler, compilation)
+        .then((res) => done())
     })
 
     // grab the sources and dependencies and export them into the right files
     // have webpack export them into their own files
     compiler.plugin('emit', (compilation, done) => {
-      this.files.forEach((f) => {
+      compiler.options.files.css.forEach((f) => {
         const dep = compilation.modules.find((el) => {
           if (el.userRequest === f) { return el }
         })

--- a/lib/plugins/jade_plugin.js
+++ b/lib/plugins/jade_plugin.js
@@ -15,18 +15,21 @@ export default class JadeWebpackPlugin {
 
   apply (compiler) {
     // read file tree and get all jade files
-    this.files = util.getFilesFromGlob(compiler, this.opts)
+    compiler.plugin('run', (compilation, done) => {
+      compiler.options.files = util.getFilesFromGlob(compiler, this.opts)
+      done()
+    })
 
     // inject jade files into webpack's pipeline
     compiler.plugin('make', (compilation, done) => {
-      util.addFilesAsWebpackEntries(this.files, this.opts, compiler, compilation)
-          .then((res) => done())
+      util.addFilesAsWebpackEntries(compiler.options.files.jade, this.opts, compiler, compilation)
+        .then((res) => done())
     })
 
     // grab the sources and dependencies and export them into the right files
     // have webpack export them into their own files
     compiler.plugin('emit', (compilation, done) => {
-      this.files.forEach((f) => {
+      compiler.options.files.jade.forEach((f) => {
         const dep = compilation.modules.find((el) => {
           if (el.userRequest === f) { return el }
         })

--- a/lib/plugins/plugin_utils.js
+++ b/lib/plugins/plugin_utils.js
@@ -5,8 +5,13 @@ import SingleEntryDependency from 'webpack/lib/dependencies/SingleEntryDependenc
 
 export default {
   getFilesFromGlob (compiler, opts) {
-    const matcher = path.join(compiler.options.context, opts.matcher)
-    const files = glob.sync(matcher, { ignore: opts.ignore })
+    let files = {}
+    const matcher = path.join(compiler.options.context, '**/**')
+    files._all = glob.sync(matcher, { ignore: opts.ignore })
+
+    for (let key in opts.matchers) {
+      files[key] = micromatch(files._all, opts.matchers[key])
+    }
     return files
   },
   addFilesAsWebpackEntries (files, opts, compiler, compilation) {
@@ -37,9 +42,11 @@ export default {
     return rel.substring(1)
   },
   removeAssets (compilation, opts, done) {
-    for (const a in compilation.assets) {
-      if (a.substring(0, a.length - 3).match(mmToRe(opts.matcher))) {
-        delete compilation.assets[a]
+    for (let key in opts.matchers) {
+      for (const a in compilation.assets) {
+        if (a.substring(0, a.length - 3).match(mmToRe(opts.matchers[key]))) {
+          delete compilation.assets[a]
+        }
       }
     }
     done()

--- a/lib/plugins/static_plugin.js
+++ b/lib/plugins/static_plugin.js
@@ -11,12 +11,9 @@ export default class StaticWebpackPlugin {
   }
 
   apply (compiler) {
-    // read file tree and get all static files
-    this.files = util.getFilesFromGlob(compiler, this.opts)
-
     // inject static files into webpack's pipeline
     compiler.plugin('make', (compilation, done) => {
-      util.addFilesAsWebpackEntries(this.files, this.opts, compiler, compilation)
+      util.addFilesAsWebpackEntries(compiler.options.files.static, this.opts, compiler, compilation)
         .then((res) => done())
     })
 


### PR DESCRIPTION
now the jade plugin (presumptively because it's listed first in the `plugins` array) only searches the fs once and then shares that info w/ the other (css, static) plugins by tacking it to the webpack compiler object (`compiler.options.files`)

i'm using `compiler.options.files` but it could be just `compiler.files` if we wanted, but since we're already using `compiler.options` for `locals`, it'd be nice to have it in 1 place. also, `compiler.options` isn't an unwieldily monster object like `compiler` is. perhaps longterm we'll namespace like `compiler.roots` - but for now this does the trick. 