### PR TITLE
[wip] improve loaders logic

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -47,6 +47,9 @@ export default class Config {
       ignore: Joi.array().default([]),
       entry: Joi.object().default({ 'js/main': ['./assets/js/index.js'] }),
       modulesDirectories: Joi.array().default(['node_modules', 'bower_components']),
+      module: Joi.object().default().keys({
+        loaders: Joi.array().default([])
+      }),
       outputDir: Joi.string().default('public'),
       jadeTemplates: Joi.bool().default(false),
       cssTemplates: Joi.bool().default(false),
@@ -134,21 +137,24 @@ export default class Config {
 
     this.resolveLoader = {
       root: [
-        path.join(__dirname, '../node_modules'), // local, global
-        path.join(__dirname, '../../../node_modules') // flattened, via npm 3+
+        path.join(opts.root), // the project root
+        path.join(__dirname, '../node_modules'), // roots-mini/node_modules
+        path.join(__dirname, '../../../node_modules') // roots-mini's flattened deps, via npm 3+
       ]
     }
 
     // ignore node_modules and output directory automatically
     opts.ignore.unshift('**/node_modules/**', `${this.output.path}/**`)
 
+    const rootsLoaders = [
+      { test: mmToRe(opts.matchers.css), exclude: opts.ignore.map(mmToRe), loader: 'css-loader!postcss-loader' },
+      { test: mmToRe(opts.matchers.js), exclude: opts.ignore.map(mmToRe), loader: 'babel-loader!vue-loader' },
+      { test: mmToRe(opts.matchers.jade), exclude: opts.ignore.map(mmToRe), loader: 'jade-loader', query: { pretty: true, locals: this.locals } },
+      { test: mmToRe(opts.matchers.static), exclude: opts.ignore.map(mmToRe), loader: 'file-loader', query: { dumpDirs: opts.dumpDirs } }
+    ]
+
     this.module = {
-      loaders: [
-        { test: mmToRe(opts.matchers.css), exclude: opts.ignore.map(mmToRe), loader: 'css!postcss' },
-        { test: mmToRe(opts.matchers.js), exclude: opts.ignore.map(mmToRe), loader: 'babel' },
-        { test: mmToRe(opts.matchers.jade), exclude: opts.ignore.map(mmToRe), loader: 'jade', query: { pretty: true, locals: this.locals } },
-        { test: mmToRe(opts.matchers.static), exclude: opts.ignore.map(mmToRe), loader: 'file', query: { dumpDirs: opts.dumpDirs } }
-      ]
+      loaders: opts.module.loaders.concat(rootsLoaders)
     }
 
     this.postcss = function (wp) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -148,14 +148,13 @@ export default class Config {
 
     const rootsLoaders = [
       { test: mmToRe(opts.matchers.css), exclude: opts.ignore.map(mmToRe), loader: 'css-loader!postcss-loader' },
-      { test: mmToRe(opts.matchers.js), exclude: opts.ignore.map(mmToRe), loader: 'babel-loader!vue-loader' },
+      { test: mmToRe(opts.matchers.js), exclude: opts.ignore.map(mmToRe), loader: 'babel-loader' },
       { test: mmToRe(opts.matchers.jade), exclude: opts.ignore.map(mmToRe), loader: 'jade-loader', query: { pretty: true, locals: this.locals } },
       { test: mmToRe(opts.matchers.static), exclude: opts.ignore.map(mmToRe), loader: 'file-loader', query: { dumpDirs: opts.dumpDirs } }
     ]
 
-    this.module = {
-      loaders: opts.module.loaders.concat(rootsLoaders)
-    }
+    this.module = opts.module
+    this.module.loaders = opts.module.loaders.concat(rootsLoaders)
 
     this.postcss = function (wp) {
       opts.postcss.plugins.unshift(postcssImport({ addDependencyTo: wp }))


### PR DESCRIPTION
- allow `module.loaders` defined in app.js
- default loader priority to project root
- be explicit w/ internal loaders, so that things like `./node_modules/postcss` aren't attempted as webpack loaders