### PR TITLE
Loader hotfix

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -134,8 +134,9 @@ export default class Config {
 
     this.resolveLoader = {
       root: [
-        path.join(__dirname, '../node_modules'), // local, global
-        path.join(__dirname, '../../../node_modules') // flattened, via npm 3+
+        path.join(opts.root), // the project root
+        path.join(__dirname, '../node_modules'), // roots-mini/node_modules
+        path.join(__dirname, '../../../node_modules') // roots-mini's flattened deps, via npm 3+
       ]
     }
 
@@ -144,10 +145,10 @@ export default class Config {
 
     this.module = {
       loaders: [
-        { test: mmToRe(opts.matchers.css), exclude: opts.ignore.map(mmToRe), loader: 'css!postcss' },
-        { test: mmToRe(opts.matchers.js), exclude: opts.ignore.map(mmToRe), loader: 'babel' },
-        { test: mmToRe(opts.matchers.jade), exclude: opts.ignore.map(mmToRe), loader: 'jade', query: { pretty: true, locals: this.locals } },
-        { test: mmToRe(opts.matchers.static), exclude: opts.ignore.map(mmToRe), loader: 'file', query: { dumpDirs: opts.dumpDirs } }
+        { test: mmToRe(opts.matchers.css), exclude: opts.ignore.map(mmToRe), loader: 'css-loader!postcss-loader' },
+        { test: mmToRe(opts.matchers.js), exclude: opts.ignore.map(mmToRe), loader: 'babel-loader' },
+        { test: mmToRe(opts.matchers.jade), exclude: opts.ignore.map(mmToRe), loader: 'jade-loader', query: { pretty: true, locals: this.locals } },
+        { test: mmToRe(opts.matchers.static), exclude: opts.ignore.map(mmToRe), loader: 'file-loader', query: { dumpDirs: opts.dumpDirs } }
       ]
     }
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "when": "^3.7.7"
   },
   "devDependencies": {
-    "ava": "^0.11.0",
+    "ava": "^0.13.0",
     "babel-cli": "^6.5.1",
     "babel-eslint": "^4.1.6",
     "babel-plugin-rewire": "1.0.0-beta-5",


### PR DESCRIPTION
- updates ava
- uses explicit loaders as to not cause unforeseen collisions
- allow a loader override by defining it in your project's `package.json` 

there's more work to be done to be able to accept custom loaders in `app.js`, but these changes are the first step. we can address custom loader definitions in a future PR